### PR TITLE
Added a version check before calling http.socket_timeout 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,16 @@
 dist: trusty
 sudo: false
 language: python
+env:
+  - PY2NEO_VERSION=3
+  - PY2NEO_VERSION=4
 python:
   - "3.4"
   - "3.5"
   - "3.6"
 install:
   - pip install .[test]
+  - pip install py2neo==$PY2NEO_VERSION
   - python setup.py sdist bdist_wheel
 script:
   - py.test

--- a/hetio/neo4j.py
+++ b/hetio/neo4j.py
@@ -6,7 +6,6 @@ from operator import or_
 from functools import reduce
 
 import py2neo
-import py2neo.packages.httpstream
 import pandas
 from tqdm import tqdm
 
@@ -15,8 +14,10 @@ import hetio.hetnet
 # Get py2neo version
 PY2NEO_VER = int(py2neo.__version__[0])
 
-# Avoid SocketError
-py2neo.packages.httpstream.http.socket_timeout = 1e8
+if PY2NEO_VER < 4:
+    import py2neo.packages.httpstream
+    # Avoid SocketError
+    py2neo.packages.httpstream.http.socket_timeout = 1e8
 
 def export_neo4j(graph, uri, node_queue=200, edge_queue=5, show_progress=False):
     """Export hetnet to neo4j"""


### PR DESCRIPTION
Addressing #31 

This should make it possible to import neo4j.py regardless of which py2neo version you're using. I looked at the documentation for version 4 and the functions that actually use py2neo should still work fine. I'd write tests for them to make sure that's the case, but they all modify or delete information in existing neo4j databases. It should be possible to spin up a neo4j database at test time if we want to take that route.