### PR TITLE
Optimize, refactor, and add tests to construct_pdp_query

### DIFF
--- a/hetio/neo4j.py
+++ b/hetio/neo4j.py
@@ -469,13 +469,11 @@ def construct_pdp_query(metarels, dwpc=None, path_style='list', property='name',
             {degree_query}
             ] AS degrees, path
             WITH path, reduce(pdp = 1.0, d in degrees| pdp * d ^ -{{ w }}) AS PDP
-            WITH path, collect(PDP) AS pdps, PDP
-            WITH collect({{path: path, pdps: pdps}}) AS allData, sum(PDP) AS DWPC
+            WITH collect({{paths: path, pdps: PDP}}) AS allData, sum(PDP) AS DWPC
             UNWIND allData AS data
-            UNWIND data.pdps AS PDP
-            WITH data.path AS path, PDP, DWPC
+            WITH data.paths AS path, data.pdps AS PDP, DWPC
             RETURN
-              substring(reduce(s = '', node IN nodes(path)| s + '–' + node.name), 1) AS path,
+              {path_query}
               PDP,
               100 * (PDP / DWPC) AS PERCENT_OF_DWPC
             ORDER BY PERCENT_OF_DWPC DESC
@@ -485,7 +483,8 @@ def construct_pdp_query(metarels, dwpc=None, path_style='list', property='name',
             unique_nodes_query = unique_nodes_query,
             degree_query = degree_query,
             length=len(metarels),
-            property=property)
+            property=property,
+            path_query = path_query)
 
     return query
 

--- a/hetio/neo4j.py
+++ b/hetio/neo4j.py
@@ -176,6 +176,117 @@ def cypher_path(metarels):
         q += '{dir0}[:{rel_type}]{dir1}(n{i}{target_label})'.format(**kwargs)
     return q
 
+def construct_degree_clause(metarels):
+    """
+    Create a Cypher query clause that calculates the degree of each node
+
+    Parameters
+    ----------
+    metarels : a metarels or MetaPath object
+        the metapath to create the clause for
+    """
+
+    degree_strs = list()
+    for i, (source_label, target_label, rel_type, direction) in enumerate(metarels):
+        kwargs = {
+            'i0': i,
+            'i1': i + 1,
+            'source_label': source_label,
+            'target_label': target_label,
+            'rel_type': rel_type,
+            'dir0': '<-' if direction == 'backward' else '-',
+            'dir1': '->' if direction == 'forward' else '-',
+        }
+        degree_strs.append(textwrap.dedent(
+            '''\
+            size((n{i0}){dir0}[:{rel_type}]{dir1}()),
+            size((){dir0}[:{rel_type}]{dir1}(n{i1}))'''
+            ).format(**kwargs))
+    degree_query = ',\n'.join(degree_strs)
+
+    return degree_query
+
+def construct_using_clause(metarels, join_hint, index_hint):
+    """
+    Create a Cypher query clause that gives the planner hints to speed up the query
+
+    Parameters
+    ----------
+    metarels : a metarels or MetaPath object
+        the metapath to create the clause for
+    join_hint : 'midpoint', bool, or int
+        whether to add a join hint to tell neo4j to traverse form both ends of
+        the path and join at a specific index. `'midpoint'` or `True` specifies
+        joining at the middle node in the path (rounded down if an even number
+        of nodes). `False` specifies not to add a join hint. An int specifies
+        the node to join on.
+    index_hint : bool
+        whether to add index hints which specifies the properties of the source
+        and target nodes to use for lookup. Enabling both `index_hint` and
+        `join_hint` can cause the query to fail.
+    """
+    using_query = ''
+    # Specify index hint for node lookup
+    if index_hint:
+        using_query = '\n' + textwrap.dedent('''\
+        USING INDEX n0:{source_label}({property})
+        USING INDEX n{length}:{target_label}({property})
+        ''').rstrip().format(
+            property = property,
+            source_label = metarels[0][0],
+            target_label = metarels[-1][1],
+            length = len(metarels)
+        )
+
+    # Specify join hint with node to join on
+    if join_hint is not False:
+        if join_hint is True or join_hint == 'midpoint':
+            join_hint = len(metarels) // 2
+        join_hint = int(join_hint)
+        assert join_hint >= 0
+        assert join_hint <= len(metarels)
+        using_query += "\nUSING JOIN ON n{}".format(join_hint)
+
+    return using_query
+
+def construct_unique_nodes_clause(metarels, unique_nodes):
+    """
+    Create a Cypher query clause that gives the planner hints to speed up the query
+
+    Parameters
+    ----------
+    metarels : a metarels or MetaPath object
+        the metapath to create the clause for
+    unique_nodes : bool or str
+        whether to exclude paths with duplicate nodes. To not enforce node
+        uniqueness, use `False`. Methods for enforcing node uniqueness are:
+        `nested` the path-length independent query (`ALL (x IN nodes(path) WHERE size(filter(z IN nodes(path) WHERE z = x)) = 1)`)
+        `expanded` for the combinatorial and path-length dependent form (`NOT (n0=n1 OR n0=n2 OR n0=n3 OR n1=n2 OR n1=n3 OR n2=n3)`).
+        `labeled` to perform an intelligent version of `expanded` where only
+        nodes with the same label are checked for duplicity. Specifying `True`,
+        which is the default, uses the `labeled` method.
+    """
+    if unique_nodes == 'nested':
+        unique_nodes_query = '\nAND ALL (x IN nodes(path) WHERE size(filter(z IN nodes(path) WHERE z = x)) = 1)'
+    elif unique_nodes == 'expanded':
+        pairs = itertools.combinations(range(len(metarels) + 1), 2)
+        unique_nodes_query = format_expanded_clause(pairs)
+    elif unique_nodes == 'labeled' or unique_nodes is True:
+        labels = [metarel[0] for metarel in metarels]
+        labels.append(metarels[-1][1])
+        label_to_nodes = dict()
+        for i, label in enumerate(labels):
+            label_to_nodes.setdefault(label, list()).append(i)
+        pairs = list()
+        for nodes in label_to_nodes.values():
+            pairs.extend(itertools.combinations(nodes, 2))
+        unique_nodes_query = format_expanded_clause(pairs)
+    else:
+        assert unique_nodes is False
+        unique_nodes_query = ''
+
+    return unique_nodes_query
+
 def construct_dwpc_query(metarels, property='name', join_hint='midpoint', index_hint=False, unique_nodes=True):
     """
     Create a cypher query for computing the *DWPC* for a type of path.
@@ -213,65 +324,12 @@ def construct_dwpc_query(metarels, property='name', join_hint='midpoint', index_
     metapath_query = cypher_path(metarels)
 
     # create cypher path degree query
-    degree_strs = list()
-    for i, (source_label, target_label, rel_type, direction) in enumerate(metarels):
-        kwargs = {
-            'i0': i,
-            'i1': i + 1,
-            'source_label': source_label,
-            'target_label': target_label,
-            'rel_type': rel_type,
-            'dir0': '<-' if direction == 'backward' else '-',
-            'dir1': '->' if direction == 'forward' else '-',
-        }
-        degree_strs.append(textwrap.dedent(
-            '''\
-            size((n{i0}){dir0}[:{rel_type}]{dir1}()),
-            size((){dir0}[:{rel_type}]{dir1}(n{i1}))'''
-            ).format(**kwargs))
-    degree_query = ',\n'.join(degree_strs)
+    degree_query = construct_degree_clause(metarels)
 
-    using_query = ''
-    # Specify index hint for node lookup
-    if index_hint:
-        using_query = '\n' + textwrap.dedent('''\
-        USING INDEX n0:{source_label}({property})
-        USING INDEX n{length}:{target_label}({property})
-        ''').rstrip().format(
-            property = property,
-            source_label = metarels[0][0],
-            target_label = metarels[-1][1],
-            length = len(metarels)
-        )
-
-    # Specify join hint with node to join on
-    if join_hint is not False:
-        if join_hint is True or join_hint == 'midpoint':
-            join_hint = len(metarels) // 2
-        join_hint = int(join_hint)
-        assert join_hint >= 0
-        assert join_hint <= len(metarels)
-        using_query += "\nUSING JOIN ON n{}".format(join_hint)
+    using_query = construct_using_clause(metarels, join_hint, index_hint)
 
     # Unique node constraint (pevent paths with duplicate nodes)
-    if unique_nodes == 'nested':
-        unique_nodes_query = '\nAND ALL (x IN nodes(path) WHERE size(filter(z IN nodes(path) WHERE z = x)) = 1)'
-    elif unique_nodes == 'expanded':
-        pairs = itertools.combinations(range(len(metarels) + 1), 2)
-        unique_nodes_query = format_expanded_clause(pairs)
-    elif unique_nodes == 'labeled' or unique_nodes is True:
-        labels = [metarel[0] for metarel in metarels]
-        labels.append(metarels[-1][1])
-        label_to_nodes = dict()
-        for i, label in enumerate(labels):
-            label_to_nodes.setdefault(label, list()).append(i)
-        pairs = list()
-        for nodes in label_to_nodes.values():
-            pairs.extend(itertools.combinations(nodes, 2))
-        unique_nodes_query = format_expanded_clause(pairs)
-    else:
-        assert unique_nodes is False
-        unique_nodes_query = ''
+    unique_nodes_query = construct_unique_nodes_clause(metarels, unique_nodes)
 
     # combine cypher fragments into a single query and add DWPC logic
     query = textwrap.dedent('''\
@@ -337,65 +395,12 @@ def construct_pdp_query(metarels, dwpc=None, property='name', join_hint='midpoin
     metapath_query = cypher_path(metarels)
 
     # create cypher path degree query
-    degree_strs = list()
-    for i, (source_label, target_label, rel_type, direction) in enumerate(metarels):
-        kwargs = {
-            'i0': i,
-            'i1': i + 1,
-            'source_label': source_label,
-            'target_label': target_label,
-            'rel_type': rel_type,
-            'dir0': '<-' if direction == 'backward' else '-',
-            'dir1': '->' if direction == 'forward' else '-',
-        }
-        degree_strs.append(textwrap.dedent(
-            '''\
-            size((n{i0}){dir0}[:{rel_type}]{dir1}()),
-            size((){dir0}[:{rel_type}]{dir1}(n{i1}))'''
-            ).format(**kwargs))
-    degree_query = ',\n'.join(degree_strs)
+    degree_query = construct_degree_clause(metarels)
 
-    using_query = ''
-    # Specify index hint for node lookup
-    if index_hint:
-        using_query = '\n' + textwrap.dedent('''\
-        USING INDEX n0:{source_label}({property})
-        USING INDEX n{length}:{target_label}({property})
-        ''').rstrip().format(
-            property = property,
-            source_label = metarels[0][0],
-            target_label = metarels[-1][1],
-            length = len(metarels)
-        )
-
-    # Specify join hint with node to join on
-    if join_hint is not False:
-        if join_hint is True or join_hint == 'midpoint':
-            join_hint = len(metarels) // 2
-        join_hint = int(join_hint)
-        assert join_hint >= 0
-        assert join_hint <= len(metarels)
-        using_query += "\nUSING JOIN ON n{}".format(join_hint)
+    using_query = construct_using_clause(metarels, join_hint, index_hint)
 
     # Unique node constraint (pevent paths with duplicate nodes)
-    if unique_nodes == 'nested':
-        unique_nodes_query = '\nAND ALL (x IN nodes(path) WHERE size(filter(z IN nodes(path) WHERE z = x)) = 1)'
-    elif unique_nodes == 'expanded':
-        pairs = itertools.combinations(range(len(metarels) + 1), 2)
-        unique_nodes_query = format_expanded_clause(pairs)
-    elif unique_nodes == 'labeled' or unique_nodes is True:
-        labels = [metarel[0] for metarel in metarels]
-        labels.append(metarels[-1][1])
-        label_to_nodes = dict()
-        for i, label in enumerate(labels):
-            label_to_nodes.setdefault(label, list()).append(i)
-        pairs = list()
-        for nodes in label_to_nodes.values():
-            pairs.extend(itertools.combinations(nodes, 2))
-        unique_nodes_query = format_expanded_clause(pairs)
-    else:
-        assert unique_nodes is False
-        unique_nodes_query = ''
+    unique_nodes_query = construct_unique_nodes_clause(metarels, unique_nodes)
 
     # combine cypher fragments into a single query and add PDP logic
     query = ''
@@ -408,9 +413,9 @@ def construct_pdp_query(metarels, dwpc=None, property='name', join_hint='midpoin
             [
             {degree_query}
             ] AS degrees, path
-            WITH path, reduce(pdp = 1.0, d in degrees| pdp * d ^ -{{ w }}) as PDP
+            WITH path, reduce(pdp = 1.0, d in degrees| pdp * d ^ -{{ w }}) AS PDP
             RETURN
-            path,
+            substring(reduce(s = '', node IN nodes(path)| s + '–' + node.name), 1) AS path,
             PDP,
             100 * (PDP / {dwpc}) AS PERCENT_OF_DWPC
             ORDER BY PERCENT_OF_DWPC DESC
@@ -422,9 +427,8 @@ def construct_pdp_query(metarels, dwpc=None, property='name', join_hint='midpoin
             length=len(metarels),
             property=property,
             dwpc = dwpc)
-    # If the dwpc isn't provided, we'll have to calculate it before the PDP.
-    # Doing so roughly doubles the query execution time, as it effectively
-    # runs the query twice returning different degrees of aggregation.
+
+    # https://stackoverflow.com/questions/54245415/
     else:
         query = textwrap.dedent('''\
             MATCH path = {metapath_query}{using_query}
@@ -434,20 +438,16 @@ def construct_pdp_query(metarels, dwpc=None, property='name', join_hint='midpoin
             [
             {degree_query}
             ] AS degrees, path
-            WITH sum(reduce(pdp = 1.0, d in degrees| pdp * d ^ -{{ w }})) as DWPC
-
-            MATCH path = {metapath_query}{using_query}
-            WHERE n0.{property} = {{ source }}
-            AND n{length}.{property} = {{ target }}{unique_nodes_query}
-            WITH
-            [
-            {degree_query}
-            ] AS degrees, path, DWPC
-            WITH path, DWPC, reduce(pdp = 1.0, d in degrees| pdp * d ^ -{{ w }}) as PDP
+            WITH path, reduce(pdp = 1.0, d in degrees| pdp * d ^ -{{ w }}) AS PDP
+            WITH path, collect(PDP) AS pdps, PDP
+            WITH collect({{path: path, pdps: pdps}}) AS allData, sum(PDP) AS DWPC
+            UNWIND allData AS data
+            UNWIND data.pdps AS PDP
+            WITH data.path AS path, PDP, DWPC
             RETURN
-            path,
-            PDP,
-            100 * (PDP / DWPC) AS PERCENT_OF_DWPC
+              substring(reduce(s = '', node IN nodes(path)| s + '–' + node.name), 1) AS path,
+              PDP,
+              100 * (PDP / DWPC) AS PERCENT_OF_DWPC
             ORDER BY PERCENT_OF_DWPC DESC
             ''').rstrip().format(
             metapath_query = metapath_query,
@@ -456,7 +456,6 @@ def construct_pdp_query(metarels, dwpc=None, property='name', join_hint='midpoin
             degree_query = degree_query,
             length=len(metarels),
             property=property)
-
 
     return query
 

--- a/hetio/neo4j.py
+++ b/hetio/neo4j.py
@@ -475,9 +475,9 @@ def construct_pdp_query(metarels, dwpc=None, path_style='list', return_property=
             {degree_query}
             ] AS degrees, path
             WITH path, reduce(pdp = 1.0, d in degrees| pdp * d ^ -{{ w }}) AS PDP
-            WITH collect({{paths: path, pdps: PDP}}) AS allData, sum(PDP) AS DWPC
-            UNWIND allData AS data
-            WITH data.paths AS path, data.pdps AS PDP, DWPC
+            WITH collect({{paths: path, PDPs: PDP}}) AS data_maps, sum(PDP) AS DWPC
+            UNWIND data_maps AS data_map
+            WITH data_map.paths AS path, data_map.PDPs AS PDP, DWPC
             RETURN
               {path_query}
               PDP,

--- a/hetio/neo4j.py
+++ b/hetio/neo4j.py
@@ -310,7 +310,7 @@ def create_path_return_clause(path_style='list', return_property='name'):
                       "create_path_return_clause. Valid styles are "
                       "'list' and 'string'").format(style=path_style)
 
-        raise Exception(err_string)
+        raise ValueError(err_string)
 
 def construct_dwpc_query(metarels, property='name', join_hint='midpoint', index_hint=False, unique_nodes=True):
     """

--- a/hetio/neo4j.py
+++ b/hetio/neo4j.py
@@ -287,6 +287,29 @@ def construct_unique_nodes_clause(metarels, unique_nodes):
 
     return unique_nodes_query
 
+def create_path_return_clause(path_style='list'):
+    """
+    Create a Cypher query clause to return paths either as a list or as a string.
+    As formatting the output as a string is less efficient in terms of database
+    hits, 'list' is the default style
+
+    Parameters
+    ----------
+    path_style : str
+        the way the user wants the path returned. Currently supported options
+        are 'list' and 'string'
+    """
+    if path_style == 'string':
+        return "substring(reduce(s = '', node IN nodes(path)| s + '–' + node.name), 1) AS path,"
+    elif path_style == 'list':
+        return "extract(n in nodes(path) | n.name) AS path,"
+    else:
+        err_string = str(path_style) + (" is not a style currently implemented by "
+                                        "create_path_return_clause. Valid styles are "
+                                        "'list' and 'string'")
+
+        raise Exception(err_string)
+
 def construct_dwpc_query(metarels, property='name', join_hint='midpoint', index_hint=False, unique_nodes=True):
     """
     Create a cypher query for computing the *DWPC* for a type of path.
@@ -353,7 +376,7 @@ def construct_dwpc_query(metarels, property='name', join_hint='midpoint', index_
 
     return query
 
-def construct_pdp_query(metarels, dwpc=None, property='name', join_hint='midpoint', index_hint=False, unique_nodes=True):
+def construct_pdp_query(metarels, dwpc=None, path_style='list', property='name', join_hint='midpoint', index_hint=False, unique_nodes=True):
     """
     Create a Cypher query for computing the path degree product for a type of path.
     This function is very similar to construct_dwpc_query, with the main changes occuring in the
@@ -366,6 +389,9 @@ def construct_pdp_query(metarels, dwpc=None, property='name', join_hint='midpoin
     dwpc : int
         the degree-weighted path count for the metapath. If dwpc is not provided,
         a subquery will be added to calculate it.
+    path_style: str
+        the style in which the path information should be returned. This style is
+        used by the create_path_return_clause function
     property : str
         which property to use for soure and target node lookup
     join_hint : 'midpoint', bool, or int
@@ -402,6 +428,9 @@ def construct_pdp_query(metarels, dwpc=None, property='name', join_hint='midpoin
     # Unique node constraint (pevent paths with duplicate nodes)
     unique_nodes_query = construct_unique_nodes_clause(metarels, unique_nodes)
 
+    # decide how the path will be returned
+    path_query = create_path_return_clause(path_style=path_style)
+
     # combine cypher fragments into a single query and add PDP logic
     query = ''
     if dwpc is not None:
@@ -415,7 +444,7 @@ def construct_pdp_query(metarels, dwpc=None, property='name', join_hint='midpoin
             ] AS degrees, path
             WITH path, reduce(pdp = 1.0, d in degrees| pdp * d ^ -{{ w }}) AS PDP
             RETURN
-            substring(reduce(s = '', node IN nodes(path)| s + '–' + node.name), 1) AS path,
+            {path_query}
             PDP,
             100 * (PDP / {dwpc}) AS PERCENT_OF_DWPC
             ORDER BY PERCENT_OF_DWPC DESC
@@ -426,6 +455,7 @@ def construct_pdp_query(metarels, dwpc=None, property='name', join_hint='midpoin
             degree_query = degree_query,
             length=len(metarels),
             property=property,
+            path_query = path_query,
             dwpc = dwpc)
 
     # https://stackoverflow.com/questions/54245415/

--- a/test/neo4j_test.py
+++ b/test/neo4j_test.py
@@ -152,7 +152,6 @@ def test_construct_pdp_query_return_values():
 
     assert DWPC_query == q2
 
-
 def test_construct_dwpc_query():
     """
     Test dwpc query construction and computation on the metapath from
@@ -189,4 +188,3 @@ def test_construct_dwpc_query():
     dwpc = results['DWPC']
 
     assert dwpc == pytest.approx(0.03287590886921623)
-

--- a/test/neo4j_test.py
+++ b/test/neo4j_test.py
@@ -17,7 +17,7 @@ def test_construct_pdp_query():
     # Set up the graph for querying
 
     directory = pathlib.Path(__file__).parent.absolute()
-    path = directory.joinpath('data/bupropion-CbGpPWpGaD-subgraph.json.gz')
+    path = directory.joinpath('data/hetionet-v1.0-metagraph.json')
 
     metagraph = hetio.readwrite.read_metagraph(path)
 
@@ -135,7 +135,7 @@ def test_construct_pdp_query_return_values():
 
     # Set up the graph for querying
     directory = pathlib.Path(__file__).parent.absolute()
-    path = directory.joinpath('data/bupropion-CbGpPWpGaD-subgraph.json.gz')
+    path = directory.joinpath('data/hetionet-v1.0-metagraph.json')
     metagraph = hetio.readwrite.read_metagraph(path)
 
     metapath = metagraph.metapath_from_abbrev('CbGpPWpGaD')
@@ -154,7 +154,7 @@ def test_construct_dwpc_query():
     """
 
     directory = pathlib.Path(__file__).parent.absolute()
-    path = directory.joinpath('data/bupropion-CbGpPWpGaD-subgraph.json.gz')
+    path = directory.joinpath('data/hetionet-v1.0-metagraph.json')
 
     metagraph = hetio.readwrite.read_metagraph(path)
 

--- a/test/neo4j_test.py
+++ b/test/neo4j_test.py
@@ -19,9 +19,7 @@ def test_construct_pdp_query():
     directory = pathlib.Path(__file__).parent.absolute()
     path = directory.joinpath('data/bupropion-CbGpPWpGaD-subgraph.json.gz')
 
-    graph = hetio.readwrite.read_graph(path)
-    assert graph is not None
-    metagraph = graph.metagraph
+    metagraph = hetio.readwrite.read_metagraph(path)
 
     compound = 'DB01156'  # Bupropion
     disease = 'DOID:0050742'  # nicotine dependency
@@ -140,8 +138,7 @@ def test_construct_pdp_query_return_values():
     # Set up the graph for querying
     directory = pathlib.Path(__file__).parent.absolute()
     path = directory.joinpath('data/bupropion-CbGpPWpGaD-subgraph.json.gz')
-    graph = hetio.readwrite.read_graph(path)
-    metagraph = graph.metagraph
+    metagraph = hetio.readwrite.read_metagraph(path)
 
     metapath = metagraph.metapath_from_abbrev('CbGpPWpGaD')
     DWPCless_query = hetio.neo4j.construct_pdp_query(metapath, path_style='string', property='identifier', unique_nodes=True)
@@ -161,9 +158,7 @@ def test_construct_dwpc_query():
     directory = pathlib.Path(__file__).parent.absolute()
     path = directory.joinpath('data/bupropion-CbGpPWpGaD-subgraph.json.gz')
 
-    graph = hetio.readwrite.read_graph(path)
-    assert graph is not None
-    metagraph = graph.metagraph
+    metagraph = hetio.readwrite.read_metagraph(path)
 
     compound = 'DB01156'  # Bupropion
     disease = 'DOID:0050742'  # nicotine dependency

--- a/test/neo4j_test.py
+++ b/test/neo4j_test.py
@@ -192,7 +192,7 @@ def test_construct_path_return_clause_returns(style, identifier, expected_output
     '''
     Test the results of construct_path_return_clause with different parameters
     '''
-    assert(hetio.neo4j.create_path_return_clause(style, identifier) == expected_output)
+    assert hetio.neo4j.create_path_return_clause(style, identifier) == expected_output
 
 def test_construct_path_return_clause_error():
     '''

--- a/test/neo4j_test.py
+++ b/test/neo4j_test.py
@@ -97,11 +97,9 @@ def test_construct_pdp_query_return_values():
             size(()-[:ASSOCIATES_DaG]-(n4))
             ] AS degrees, path
             WITH path, reduce(pdp = 1.0, d in degrees| pdp * d ^ -{ w }) AS PDP
-            WITH path, collect(PDP) AS pdps, PDP
-            WITH collect({path: path, pdps: pdps}) AS allData, sum(PDP) AS DWPC
+            WITH collect({paths: path, pdps: PDP}) AS allData, sum(PDP) AS DWPC
             UNWIND allData AS data
-            UNWIND data.pdps AS PDP
-            WITH data.path AS path, PDP, DWPC
+            WITH data.paths AS path, data.pdps AS PDP, DWPC
             RETURN
               substring(reduce(s = '', node IN nodes(path)| s + '–' + node.name), 1) AS path,
               PDP,

--- a/test/neo4j_test.py
+++ b/test/neo4j_test.py
@@ -97,9 +97,9 @@ def test_construct_pdp_query_return_values():
             size(()-[:ASSOCIATES_DaG]-(n4))
             ] AS degrees, path
             WITH path, reduce(pdp = 1.0, d in degrees| pdp * d ^ -{ w }) AS PDP
-            WITH collect({paths: path, pdps: PDP}) AS allData, sum(PDP) AS DWPC
-            UNWIND allData AS data
-            WITH data.paths AS path, data.pdps AS PDP, DWPC
+            WITH collect({paths: path, PDPs: PDP}) AS data_maps, sum(PDP) AS DWPC
+            UNWIND data_maps AS data_map
+            WITH data_map.paths AS path, data_map.PDPs AS PDP, DWPC
             RETURN
               substring(reduce(s = '', node IN nodes(path)| s + '–' + node.name), 1) AS path,
               PDP,

--- a/test/neo4j_test.py
+++ b/test/neo4j_test.py
@@ -189,8 +189,14 @@ def test_construct_dwpc_query():
     ('string', 'identifier', "substring(reduce(s = '', node IN nodes(path)| s + '–' + node.identifier), 1) AS path,")
     ])
 def test_construct_path_return_clause_returns(style, identifier, expected_output):
+    '''
+    Test the results of construct_path_return_clause with different parameters
+    '''
     assert(hetio.neo4j.create_path_return_clause(style, identifier) == expected_output)
 
 def test_construct_path_return_clause_error():
-    with pytest.raises(Exception):
+    '''
+    Ensure that construct_path_return_clause throwns a ValueError when given an invalid style
+    '''
+    with pytest.raises(ValueError):
         hetio.neo4j.create_path_return_clause('invalid_style')

--- a/test/neo4j_test.py
+++ b/test/neo4j_test.py
@@ -182,15 +182,15 @@ def test_construct_dwpc_query():
 
     assert dwpc == pytest.approx(0.03287590886921623)
 
-def test_create_path_return_clause():
-    """
-    Test whether the create_path_return_clause function behaves correctly
-    """
-    list_correct_output = "extract(n in nodes(path) | n.name) AS path,"
-    string_correct_output = "substring(reduce(s = '', node IN nodes(path)| s + '–' + node.name), 1) AS path,"
+@pytest.mark.parametrize('style, identifier, expected_output', [
+    ('list', 'name', "extract(n in nodes(path) | n.name) AS path,"),
+    ('list', 'identifier', "extract(n in nodes(path) | n.identifier) AS path,"),
+    ('string', 'name', "substring(reduce(s = '', node IN nodes(path)| s + '–' + node.name), 1) AS path,"),
+    ('string', 'identifier', "substring(reduce(s = '', node IN nodes(path)| s + '–' + node.identifier), 1) AS path,")
+    ])
+def test_construct_path_return_clause_returns(style, identifier, expected_output):
+    assert(hetio.neo4j.create_path_return_clause(style, identifier) == expected_output)
 
-    assert(hetio.neo4j.create_path_return_clause() == list_correct_output)
-    assert(hetio.neo4j.create_path_return_clause('list') == list_correct_output)
-    assert(hetio.neo4j.create_path_return_clause('string') == string_correct_output)
+def test_construct_path_return_clause_error():
     with pytest.raises(Exception):
         hetio.neo4j.create_path_return_clause('invalid_style')

--- a/test/neo4j_test.py
+++ b/test/neo4j_test.py
@@ -3,6 +3,7 @@ from neo4j.v1 import GraphDatabase
 import hetio.readwrite
 import hetio.neo4j
 import pytest
+import textwrap
 
 def test_construct_pdp_query():
     """
@@ -43,8 +44,9 @@ def test_construct_pdp_query():
         results = session.run(pdp_query, params)
         results = results.data()
 
-    assert results[0]['path'].start_node['name'] == 'Bupropion'
-    assert results[0]['path'].end_node['name'] == 'nicotine dependence'
+    # Note that these are en dashes not hyphens
+    assert results[0]['path'].split('–')[0] == 'Bupropion'
+    assert results[0]['path'].split('–')[-1] == 'nicotine dependence'
 
     percent_dwpc_1 = results[0]['PERCENT_OF_DWPC']
 
@@ -60,12 +62,12 @@ def test_construct_pdp_query():
         results = session.run(pdp_query, params)
         results = results.data()
 
-    assert results[0]['path'].start_node['name'] == 'Bupropion'
-    assert results[0]['path'].end_node['name'] == 'nicotine dependence'
+    assert results[0]['path'].split('–')[0] == 'Bupropion'
+    assert results[0]['path'].split('–')[-1] == 'nicotine dependence'
 
     # We'll check this because it verifies both that the DWPC and the PDP for the path
     # are the same for both queries
-    assert percent_dwpc_1 == results[0]['PERCENT_OF_DWPC']
+    assert percent_dwpc_1 == pytest.approx(results[0]['PERCENT_OF_DWPC'])
 
     sum_percent = 0
     for result in results:
@@ -74,9 +76,86 @@ def test_construct_pdp_query():
     # The fractions should all add up to around 100 percent
     assert sum_percent == pytest.approx(100)
 
+def test_construct_pdp_query_return_values():
+    """
+    Test that the construct_pdp_query function returns the expected query for a
+    known graph. These tests will not actually execute the query
+    """
+    q1 = textwrap.dedent("""\
+            MATCH path = (n0:Compound)-[:BINDS_CbG]-(n1)-[:PARTICIPATES_GpPW]-(n2)-[:PARTICIPATES_GpPW]-(n3)-[:ASSOCIATES_DaG]-(n4:Disease)
+            USING JOIN ON n2
+            WHERE n0.identifier = { source }
+            AND n4.identifier = { target }
+            AND n1 <> n3
+            WITH
+            [
+            size((n0)-[:BINDS_CbG]-()),
+            size(()-[:BINDS_CbG]-(n1)),
+            size((n1)-[:PARTICIPATES_GpPW]-()),
+            size(()-[:PARTICIPATES_GpPW]-(n2)),
+            size((n2)-[:PARTICIPATES_GpPW]-()),
+            size(()-[:PARTICIPATES_GpPW]-(n3)),
+            size((n3)-[:ASSOCIATES_DaG]-()),
+            size(()-[:ASSOCIATES_DaG]-(n4))
+            ] AS degrees, path
+            WITH path, reduce(pdp = 1.0, d in degrees| pdp * d ^ -{ w }) AS PDP
+            WITH path, collect(PDP) AS pdps, PDP
+            WITH collect({path: path, pdps: pdps}) AS allData, sum(PDP) AS DWPC
+            UNWIND allData AS data
+            UNWIND data.pdps AS PDP
+            WITH data.path AS path, PDP, DWPC
+            RETURN
+              substring(reduce(s = '', node IN nodes(path)| s + '–' + node.name), 1) AS path,
+              PDP,
+              100 * (PDP / DWPC) AS PERCENT_OF_DWPC
+            ORDER BY PERCENT_OF_DWPC DESC
+            """).rstrip()
+
+    dwpc = 0.03287590886921623
+    q2 = textwrap.dedent("""\
+            MATCH path = (n0:Compound)-[:BINDS_CbG]-(n1)-[:PARTICIPATES_GpPW]-(n2)-[:PARTICIPATES_GpPW]-(n3)-[:ASSOCIATES_DaG]-(n4:Disease)
+            USING JOIN ON n2
+            WHERE n0.identifier = { source }
+            AND n4.identifier = { target }
+            AND n1 <> n3
+            WITH
+            [
+            size((n0)-[:BINDS_CbG]-()),
+            size(()-[:BINDS_CbG]-(n1)),
+            size((n1)-[:PARTICIPATES_GpPW]-()),
+            size(()-[:PARTICIPATES_GpPW]-(n2)),
+            size((n2)-[:PARTICIPATES_GpPW]-()),
+            size(()-[:PARTICIPATES_GpPW]-(n3)),
+            size((n3)-[:ASSOCIATES_DaG]-()),
+            size(()-[:ASSOCIATES_DaG]-(n4))
+            ] AS degrees, path
+            WITH path, reduce(pdp = 1.0, d in degrees| pdp * d ^ -{ w }) AS PDP
+            RETURN
+            substring(reduce(s = '', node IN nodes(path)| s + '–' + node.name), 1) AS path,
+            PDP,
+            100 * (PDP / 0.03287590886921623) AS PERCENT_OF_DWPC
+            ORDER BY PERCENT_OF_DWPC DESC
+            """).rstrip()
+
+    # Set up the graph for querying
+    directory = pathlib.Path(__file__).parent.absolute()
+    path = directory.joinpath('data/bupropion-CbGpPWpGaD-subgraph.json.gz')
+    graph = hetio.readwrite.read_graph(path)
+    metagraph = graph.metagraph
+
+    metapath = metagraph.metapath_from_abbrev('CbGpPWpGaD')
+    DWPCless_query = hetio.neo4j.construct_pdp_query(metapath, property='identifier', unique_nodes=True)
+
+    assert DWPCless_query == q1
+
+    DWPC_query = hetio.neo4j.construct_pdp_query(metapath, dwpc, property='identifier', unique_nodes=True)
+
+    assert DWPC_query == q2
+
+
 def test_construct_dwpc_query():
     """
-    Test dwpc query construction and computation on the metapath from 
+    Test dwpc query construction and computation on the metapath from
     https://doi.org/10.1371/journal.pcbi.1004259.g002
     """
 
@@ -110,3 +189,4 @@ def test_construct_dwpc_query():
     dwpc = results['DWPC']
 
     assert dwpc == pytest.approx(0.03287590886921623)
+


### PR DESCRIPTION
This PR addresses the changes recommended in #30, namely:

- Find a more efficient way to find what fraction of the dwpc a pdp represents
- Add tests to check that the text of the queries are what we expect before running them
- Move the code shared between construct_pdp_query and construct_dwpc_query to functions